### PR TITLE
App Install Location

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -20,6 +20,7 @@
  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.moparisthebest.appbak"
+      android:installLocation="auto"
       android:versionCode="2" android:versionName="1.0">
     <application android:icon="@drawable/icon" android:label="@string/app_name">
         <activity android:name=".AppBak"


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto". (source: https://developer.android.com/guide/topics/data/install-location.html)
